### PR TITLE
Build on Windows

### DIFF
--- a/lua/msvcbuild.bat
+++ b/lua/msvcbuild.bat
@@ -1,0 +1,26 @@
+setlocal
+@set LUA_FUNC=luaopen_nfd
+@set DLL=nfd.dll
+
+@set NFD_CFLAGS=/D_CRT_SECURE_NO_WARNINGS /I"src/include"
+
+@set LUA_INCDIR="F:\Downloads\LuaJIT\include"
+@set LUA_LIBDIR="F:\Downloads\LuaJIT\lua51.lib"
+
+@if /I LUA_INCDIR=="" ( echo LUA_INCDIR not specified in msvcbuild.bat & exit )
+@if /I LUA_LIBDIR=="" ( echo LUA_LIBDIR not specified in msvcbuild.bat & exit )
+
+@set CFLAGS=/nologo /O2
+@set LIBFLAG=/nologo /dll /export:%LUA_FUNC% /out:%DLL%
+
+rem nfd_common.obj
+cl /c %CFLAGS% %NFD_CFLAGS% "src/nfd_common.c" /Fo"nfd_common.obj"
+
+rem nfd_win.obj
+cl /c %CFLAGS% %NFD_CFLAGS% "src/nfd_win.cpp" /Fo"nfd_win.obj"
+
+rem nfd_wrap_lua.obj
+cl /c %CFLAGS% %NFD_CFLAGS% /I%LUA_INCDIR% "lua/nfd_wrap_lua.c" /Fo"nfd_wrap_lua.obj"
+
+rem nfd.dll
+link %LIBFLAG% *.obj %LUA_LIBDIR%

--- a/lua/nfd_wrap_lua.c
+++ b/lua/nfd_wrap_lua.c
@@ -33,6 +33,8 @@ static int l_open(lua_State* L)
 	    lua_pushstring(L, NFD_GetError());
 	    lua_error(L); // always returns here
 	    return -1;
+	default:
+		return 0;
     }
 }
 
@@ -75,6 +77,8 @@ static int l_openMany(lua_State* L)
 	    lua_pushstring(L, NFD_GetError());
 	    lua_error(L); // always returns here
 	    return -1;
+	default:
+		return 0;
     }
 }
 
@@ -104,6 +108,8 @@ static int l_save(lua_State* L)
 	    lua_pushstring(L, NFD_GetError());
 	    lua_error(L); // always returns here
 	    return -1;
+	default:
+		return 0;
     }
 }
 


### PR DESCRIPTION
Run `msvcbuild.bat` from the [Developer Command Prompt](https://msdn.microsoft.com/en-us/library/f35ctcxw.aspx) in order to build on Windows

Tested on Windows 10 VS2015 Community Edition

Provisory fix for #2 but a Makefile may be better and LuaRocks support would be great. Even then you can get the basic idea from this bat file

A good alternative to this build script would be a `Makefile.win` that uses [Nmake](https://msdn.microsoft.com/en-us/library/ms930369.aspx). Adding this to LuaRocks would be straightforward too
